### PR TITLE
feat: support WebContainers in CLI and WASI runtime

### DIFF
--- a/lib/index.mjs
+++ b/lib/index.mjs
@@ -7,8 +7,7 @@ export async function ripgrep(args = [], options = {}) {
     env = process.env,
     preopens = { ".": process.cwd() },
     returnOnExit = true,
-    nodeWasi = process.env.ZIGREP_NODE_WASI === "1" ||
-      (!("Bun" in globalThis) && !("Deno" in globalThis)),
+    nodeWasi = getDefaultNodeWasi(),
   } = options;
 
   // ripgrep's TTY auto-detection doesn't work through WASI preview1, so it
@@ -21,9 +20,10 @@ export async function ripgrep(args = [], options = {}) {
     args = ["--color=ansi", ...args];
   }
 
-  const wasi = await (nodeWasi ? createNodeWasi : createWasiShim)({
+  const wasi = await createWasiRuntime({
     args,
     env,
+    nodeWasi,
     preopens,
     returnOnExit,
   });
@@ -45,6 +45,31 @@ function getRgWasmModule() {
     );
   }
   return rgWasmModulePromise;
+}
+
+function getDefaultNodeWasi() {
+  if (process.env.ZIGREP_NODE_WASI === "1") return true;
+  if (process.env.ZIGREP_NODE_WASI === "0") return false;
+  return !("Bun" in globalThis) && !("Deno" in globalThis);
+}
+
+async function createWasiRuntime({
+  args,
+  env,
+  nodeWasi,
+  preopens,
+  returnOnExit,
+}) {
+  const config = { args, env, preopens, returnOnExit };
+  if (!nodeWasi) return createWasiShim(config);
+
+  try {
+    return await createNodeWasi(config);
+  } catch {
+    // Browser-hosted Node environments can expose `node:wasi` but still fail
+    // at construction or start-up. Fall back to the portable JS shim.
+    return createWasiShim(config);
+  }
 }
 
 // Custom WASI preview1 shim (see `_wasi.mjs`). Lazy-imported so consumers

--- a/lib/rg.mjs
+++ b/lib/rg.mjs
@@ -1,7 +1,12 @@
 #!/usr/bin/env node
 
-import module from "node:module";
-module.enableCompileCache?.();
+try {
+  const { enableCompileCache } = await import("node:module");
+  enableCompileCache?.();
+} catch {
+  // Some Node-compatible hosts implement enough ESM to run us but not enough
+  // of Node's module compile cache internals to make this safe.
+}
 
 const { ripgrep } = await import("./index.mjs");
 let argv = process.argv.slice(2);


### PR DESCRIPTION
Fixes #1

This makes the CLI shim safer in browser-hosted Node environments like StackBlitz WebContainers by making `enableCompileCache()` best-effort, and falls back to the existing custom WASI shim when `node:wasi` is present but not usable.

Tested in StackBlitz WebContainers with the patched package:
- programmatic `ripgrep([...])`
- CLI shim via `lib/rg.mjs`